### PR TITLE
Vouchers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-[submodule "lib/forge-std"]
-	path = lib/forge-std
-	url = https://github.com/foundry-rs/forge-std

--- a/src/ChainClaim.sol
+++ b/src/ChainClaim.sol
@@ -14,7 +14,7 @@ abstract contract ChainClaim is EIP712 {
 
   address public immutable ISSUER;
 
-  mapping(address => bool) public usedClaims;
+  mapping(bytes32 => bool) public usedVouchers;
 
   /// @notice On chain generation for a valid EIP-712 hash
   /// @param _issuer the address that must match the signing
@@ -92,11 +92,12 @@ abstract contract ChainClaim is EIP712 {
   function claim(
     address issuedAddress,
     address destinationAddress,
+    bytes32 voucherHash,
     uint8[2] memory v,
     bytes32[2] memory r,
     bytes32[2] memory s
   ) internal returns (bool) {
-    if (usedClaims[issuedAddress]) {
+    if (usedVouchers[voucherHash]) {
       revert ErrorUsedClaim();
     }
 
@@ -107,7 +108,7 @@ abstract contract ChainClaim is EIP712 {
       !isValidClaimantSig(issuedAddress, destinationAddress, v[1], r[1], s[1])
     ) revert ErrorInvalidClaimantSignature();
 
-    usedClaims[issuedAddress] = true;
+    usedVouchers[voucherHash] = true;
 
     return true;
   }

--- a/src/ChainClaim.sol
+++ b/src/ChainClaim.sol
@@ -10,7 +10,7 @@ abstract contract ChainClaim is EIP712 {
   error ErrorInvalidClaimantSignature();
 
   bytes32 private immutable _CHAIN_CLAIM_TYPEHASH =
-    keccak256("Claim(address chainedAddress)");
+    keccak256("Claim(address chainedAddress, bytes32 voucherHash)");
 
   address public immutable ISSUER;
 
@@ -27,9 +27,13 @@ abstract contract ChainClaim is EIP712 {
   /// @notice On chain generation for a valid EIP-712 hash
   /// @param chainedAddress the address that has been signed
   /// @return The typed data hash
-  function genDataHash(address chainedAddress) internal view returns (bytes32) {
+  function genDataHash(address chainedAddress, bytes32 voucherHash)
+    internal
+    view
+    returns (bytes32)
+  {
     bytes32 structHash = keccak256(
-      abi.encode(_CHAIN_CLAIM_TYPEHASH, chainedAddress)
+      abi.encode(_CHAIN_CLAIM_TYPEHASH, chainedAddress, voucherHash)
     );
 
     return _hashTypedDataV4(structHash);
@@ -44,11 +48,12 @@ abstract contract ChainClaim is EIP712 {
   /// @return True if signature is valid and signer matches issuer
   function isValidIssuerSig(
     address issuedAddress,
+    bytes32 voucherHash,
     uint8 v,
     bytes32 r,
     bytes32 s
   ) internal view returns (bool) {
-    bytes32 hash = genDataHash(issuedAddress);
+    bytes32 hash = genDataHash(issuedAddress, voucherHash);
 
     address signer = ECDSA.recover(hash, v, r, s);
 
@@ -67,11 +72,12 @@ abstract contract ChainClaim is EIP712 {
   function isValidClaimantSig(
     address issuedAddress,
     address destinationAddress,
+    bytes32 voucherHash,
     uint8 v,
     bytes32 r,
     bytes32 s
   ) internal view returns (bool) {
-    bytes32 hash = genDataHash(destinationAddress);
+    bytes32 hash = genDataHash(destinationAddress, voucherHash);
 
     address signer = ECDSA.recover(hash, v, r, s);
 
@@ -101,11 +107,11 @@ abstract contract ChainClaim is EIP712 {
       revert ErrorUsedClaim();
     }
 
-    if (!isValidIssuerSig(issuedAddress, v[0], r[0], s[0]))
+    if (!isValidIssuerSig(issuedAddress, voucherHash, v[0], r[0], s[0]))
       revert ErrorInvalidIssuerSignature();
 
     if (
-      !isValidClaimantSig(issuedAddress, destinationAddress, v[1], r[1], s[1])
+      !isValidClaimantSig(issuedAddress, destinationAddress, voucherHash, v[1], r[1], s[1])
     ) revert ErrorInvalidClaimantSignature();
 
     usedVouchers[voucherHash] = true;

--- a/src/test/ChainClaim.t.sol
+++ b/src/test/ChainClaim.t.sol
@@ -41,11 +41,12 @@ contract ExampleImplementation is ChainClaim {
 
   function takeBalance(
     address issuedAddress,
+    bytes32 voucherHash,
     uint8[2] memory v,
     bytes32[2] memory r,
     bytes32[2] memory s
   ) external {
-    bool validClaim = claim(issuedAddress, msg.sender, v, r, s);
+    bool validClaim = claim(issuedAddress, msg.sender, voucherHash, v, r, s);
 
     require(validClaim, "Invalid claim");
 
@@ -201,11 +202,14 @@ contract ChainClaimTest is ChainClaimTestSetup, DSTest {
     bytes32 hash = target._genDataHash(address(this));
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(claimCodePkey, hash);
 
+    bytes32 voucherHash = keccak256("1");
+
     vm.expectRevert(
       abi.encodePacked(bytes4(keccak256("ErrorInvalidIssuerSignature()")))
     );
     target.takeBalance(
       address(0),
+      voucherHash,
       [claimCodeV, v],
       [claimCodeR, r],
       [claimCodeS, s]
@@ -216,6 +220,7 @@ contract ChainClaimTest is ChainClaimTestSetup, DSTest {
     );
     target.takeBalance(
       claimCodeAddress,
+      voucherHash,
       [claimCodeV, v],
       [claimCodeR, r],
       [bytes32(uint256(claimCodeS) + 1), s]
@@ -226,6 +231,7 @@ contract ChainClaimTest is ChainClaimTestSetup, DSTest {
     );
     target.takeBalance(
       claimCodeAddress,
+      voucherHash,
       [claimCodeV, v],
       [claimCodeR, r],
       [claimCodeS, bytes32(uint256(s) + 1)]
@@ -233,6 +239,7 @@ contract ChainClaimTest is ChainClaimTestSetup, DSTest {
 
     target.takeBalance(
       claimCodeAddress,
+      voucherHash,
       [claimCodeV, v],
       [claimCodeR, r],
       [claimCodeS, s]
@@ -244,6 +251,7 @@ contract ChainClaimTest is ChainClaimTestSetup, DSTest {
     vm.expectRevert(abi.encodePacked(bytes4(keccak256("ErrorUsedClaim()"))));
     target.takeBalance(
       claimCodeAddress,
+      voucherHash,
       [claimCodeV, v],
       [claimCodeR, r],
       [claimCodeS, s]


### PR DESCRIPTION
Context
* Vouchers are signed payloads provided by an issuer
* Vouchers can be claimed via a claim code
* Once a voucher is claimed, an update is made in the usedVouchers registry
* usedVouchers registry used the voucherHash as it's key, to represent the unique hash of a voucher